### PR TITLE
Fix Rstp Timeout Issue

### DIFF
--- a/hikcamerabot/constants.py
+++ b/hikcamerabot/constants.py
@@ -89,6 +89,7 @@ FFMPEG_LOG_LEVEL = '-loglevel {loglevel}'
 
 # VIDEO GIF COMMAND
 FFMPEG_VIDEO_GIF_CMD = f'{FFMPEG_BIN} {FFMPEG_LOG_LEVEL} ' \
+                       f'-rtsp_transport tcp ' \
                        f'-i {FFMPEG_VIDEO_SOURCE} -t {{rec_time}}'
 
 # Livestream constants


### PR DESCRIPTION
Hardcoding tcp as the rtsp transport option when creating a GIF as timeout errors are experienced if not specified.